### PR TITLE
Feature/3-add-linter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-.idea/
+.idea
 __pycache__/

--- a/lint.sh
+++ b/lint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo ">>> $(basename ${BASH_SOURCE[0]})"
+
+set -o errexit # exit script when command fails
+set -o pipefail # this setting prevents errors in a pipeline from being masked
+set -o nounset # exit script when it tries to use undeclared variables
+
+echo 'pylint'
+pylint --load-plugins pylint_flask .
+echo 'flake8'
+flake8 .
+echo 'pycodestyle'
+pycodestyle --first .
+echo 'mypy'
+mypy . --exclude migrations
+
+echo ">>> $(basename ${BASH_SOURCE[0]}) DONE"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,80 @@
+;  Ignored rules description:
+;  pycodestyle
+;  E402 - module level import not at top of file
+;  flake8
+;  D100 - Missing docstring in public module
+;  D101 - Missing docstring in public class
+;  D102 - Missing docstring in public method
+;  D103 - Missing docstring in public function
+;  D104 - Missing docstring in public package
+;  D105 - Missing docstring in magic method
+;  D106 - Missing docstring in public nested class
+;  D107 - Missing docstring in __init__
+;  D200 - One-line docstring should fit on one line with quotes
+;  D400 - First line should end with a period
+;  D413 - Missing blank line after last section
+;  E501 - Line too long (79 characters)
+;  SF01 - Private member access
+;  T484 - Any typing error
+;  W503 - Line break occurred before a binary operator
+;  E402 - Module level import not at top of file
+
+[pycodestyle]
+max-line-length = 200
+ignore = E402
+
+[flake8]
+exclude =
+    */migrations/*
+    __pycache__,
+    .git
+    surrounding_initial_data.py
+    mind_initial_data.py
+ignore =
+    D100
+    D101
+    D102
+    D103
+    D104
+    D105
+    D106
+    D107
+    D200
+    D400
+    D413
+    E501
+    SF01
+    T484
+    W503
+    E402
+max-complexity = 12
+
+[mypy]
+mypy_path = ./stubs
+python_version = 3.8
+cache_dir = .tmp/mypy-cache
+ignore_missing_imports = True
+follow_imports = silent
+follow_imports_for_stubs = True
+disallow_any_generics = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+
+check_untyped_defs = True
+disallow_untyped_decorators = False
+no_implicit_optional = True
+strict_optional = False
+
+warn_unused_ignores = True
+warn_no_return = True
+
+show_none_errors = True
+ignore_errors = False
+
+allow_redefinition = False
+strict_equality = True
+
+show_error_context = False
+show_column_numbers = True
+
+warn_redundant_casts = True


### PR DESCRIPTION
To keep code base clean, add linter to project.

Used packages: mypy, pycodestyle, flake8, pylint

It is .sh script that runs linting for either all project files.